### PR TITLE
🗃️ Add initial database schema for user management and automation areas

### DIFF
--- a/area.sql
+++ b/area.sql
@@ -1,0 +1,75 @@
+-- Users table
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255),
+    is_verified BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- OAuth accounts (for linking third-party accounts)
+CREATE TABLE oauth_accounts (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    provider VARCHAR(50) NOT NULL,
+    provider_user_id VARCHAR(255) NOT NULL,
+    access_token TEXT,
+    refresh_token TEXT,
+    expires_at TIMESTAMP,
+    UNIQUE (provider, provider_user_id)
+);
+
+-- Services (e.g., Google, Facebook, Timer, etc.)
+CREATE TABLE services (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) UNIQUE NOT NULL,
+    description TEXT
+);
+
+-- Actions (triggers)
+CREATE TABLE actions (
+    id SERIAL PRIMARY KEY,
+    service_id INTEGER REFERENCES services(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    UNIQUE (service_id, name)
+);
+
+-- Reactions (effects)
+CREATE TABLE reactions (
+    id SERIAL PRIMARY KEY,
+    service_id INTEGER REFERENCES services(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    UNIQUE (service_id, name)
+);
+
+-- User subscriptions to services (with OAuth tokens if needed)
+CREATE TABLE user_services (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    service_id INTEGER REFERENCES services(id) ON DELETE CASCADE,
+    oauth_account_id INTEGER REFERENCES oauth_accounts(id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, service_id)
+);
+
+-- AREA: user-defined automations linking an action to a reaction
+CREATE TABLE areas (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    action_id INTEGER REFERENCES actions(id) ON DELETE CASCADE,
+    reaction_id INTEGER REFERENCES reactions(id) ON DELETE CASCADE,
+    config JSONB,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- For logging AREA executions (optional, for audit/history)
+CREATE TABLE area_executions (
+    id SERIAL PRIMARY KEY,
+    area_id INTEGER REFERENCES areas(id) ON DELETE CASCADE,
+    executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    status VARCHAR(50),
+    log TEXT
+);


### PR DESCRIPTION
## Summary
Introduces the initial database schema for the AREA application, defining all core tables and relationships required for user management, service integration, and automation workflows.

## Related Jira Issue(s)
AREA-82

## Changes
- Added `users` table for storing user accounts, supporting email/password and verification status.
- Added `oauth_accounts` table to link users with third-party OAuth providers, including token storage and uniqueness constraints.
- Added `services` table for registering third-party services (e.g., Google, Facebook).
- Added `actions` and `reactions` tables for defining triggers and effects per service, with uniqueness enforced per service.
- Added `user_services` table to track which users have connected to which services, including OAuth linkage.
- Added `areas` table to store user-defined automations that link actions to reactions, with configuration and activation status.
- Added `area_executions` table to log execution history of automations, including timestamps, status, and logs.

## Testing
- [x] CI checks pass
- [x] Manual testing completed

## Checklist
- [x] Linked to the correct Jira story
- [ ] Reviewed by at least 2 people
- [ ] All status checks pass
- [x] Source branch is based on `dev`