### PR TITLE
AREA-170 ✨  action and reaction config mandatory and not mandatory fields

### DIFF
--- a/web/src/app/pages/AreaManagement/area-creation-page/area-creation-page.css
+++ b/web/src/app/pages/AreaManagement/area-creation-page/area-creation-page.css
@@ -442,3 +442,6 @@ img {
 .disabled-popup {
     display: none;
 }
+.mandatory-field {
+    color: var(--red-color) !important;
+}

--- a/web/src/app/pages/AreaManagement/area-creation-page/area-creation-page.html
+++ b/web/src/app/pages/AreaManagement/area-creation-page/area-creation-page.html
@@ -102,7 +102,7 @@
                     </div>
                     <div class="form-fields" *ngIf="step === 3">
                         <div *ngFor="let action of actionsList">
-                            <h4>{{ action.name }}</h4>
+                            <h4 [class.mandatory-field]="action.mandatory">{{ action.name + (action.mandatory ? ' *' : '') }}</h4>
                             <app-options-field-component
                                 *ngIf="action.options_field"
                                 [label]="action.title"

--- a/web/src/app/pages/AreaManagement/area-creation-page/area-creation-page.ts
+++ b/web/src/app/pages/AreaManagement/area-creation-page/area-creation-page.ts
@@ -16,6 +16,7 @@ interface ActionField {
   id: number;
   input_field?: { placeholder: string };
   options_field?: { label: string; value: string }[];
+  mandatory: boolean;
   name: string;
   title: string;
 }
@@ -182,7 +183,7 @@ export class AreaCreationPage implements OnInit {
       if (this.reactionChosen != '' && this.reactionChosen != 'Choose Reaction') return true;
     if (this.step === 3) {
       for (const response of this.ActionsResponses) {
-        if (response.response === '' || response.response == null)
+        if ((response.response === '' || response.response == null) && this.actionsList.find(a => a.id === response.fieldId)?.mandatory)
           return false;
       }
       return true;

--- a/web/src/app/pages/AreaManagement/area-details-page/area-details-page.css
+++ b/web/src/app/pages/AreaManagement/area-details-page/area-details-page.css
@@ -351,6 +351,7 @@ img {
     }
 }
 
+
 .form-content {
     display: grid;
     grid-template-rows: 10fr auto;
@@ -439,4 +440,7 @@ img {
 }
 .disabled-popup {
     display: none;
+}
+.mandatory-field {
+    color: var(--red-color) !important;
 }

--- a/web/src/app/pages/AreaManagement/area-details-page/area-details-page.html
+++ b/web/src/app/pages/AreaManagement/area-details-page/area-details-page.html
@@ -102,7 +102,7 @@
                     </div>
                     <div class="form-fields" *ngIf="step === 3">
                         <div *ngFor="let action of actionsList">
-                            <h4>{{ action.name }}</h4>
+                            <h4 [class.mandatory-field]="action.mandatory">{{ action.name + (action.mandatory ? ' *' : '') }}</h4>
                             <app-options-field-component
                                 *ngIf="action.options_field"
                                 [label]="action.name"

--- a/web/src/app/pages/AreaManagement/area-details-page/area-details-page.ts
+++ b/web/src/app/pages/AreaManagement/area-details-page/area-details-page.ts
@@ -17,6 +17,7 @@ interface ActionField {
   id: number;
   input_field?: { placeholder: string };
   options_field?: { label: string; value: string }[];
+  mandatory: boolean;
   name: string;
   title: string;
 }
@@ -236,7 +237,7 @@ export class AreaDetailsPage implements OnInit {
       if (this.reactionChosen != '' && this.reactionChosen != 'Choose Reaction') return true;
     if (this.step === 3) {
       for (const response of this.ActionsResponses) {
-        if (response.response === '' || response.response == null)
+        if ((response.response === '' || response.response == null) && this.actionsList.find(a => a.id === response.fieldId)?.mandatory)
           return false;
       }
       return true;


### PR DESCRIPTION
## Summary
Add the mandatory option to configure fields in area

## Related Jira Issue(s)
AREA-170


## Additions
- Mandatory option in area creation
- Mandatory option in area details

## Testing
1. Configure the fields of a reaction or action with "mandatory" false / true
2. Ex : (see bottom)
3. Go in the creation page and check if the field is red & mandatory
4. Go in the details page and check if the field is red & mandatory when editing

## Checklist
- [ ] Source branch is based on `dev`
- [ ] Linked to the correct Jira story
- [ ] Added at least 2 people as reviewers, 4 if you are merging into main
- [ ] No conflicts
- [ ] Documentation deployment CI must pass


Exemple json config :

```
{
    "fields": [
        {
            "id": 1,
            "name": "Day of the Week",
            "title": "Day of the Week",
            "mandatory": true,
            "options_field": {
                "values": [
                    "Monday",
                    "Tuesday",
                    "Wednesday",
                    "Thursday",
                    "Friday",
                    "Saturday",
                    "Sunday"
                ]
            }
        },
        {
            "id": 2,
            "name": "Time (HH:MM)",
            "title": "Time (HH:MM)",
            "mandatory": true,
            "input_field": {
                "placeholder": "09:00"
            }
        },
        {
            "id": 3,
            "name": "Time2 (HH:MM)",
            "title": "Time2 (HH:MM)",
            "input_field": {
                "placeholder": "09:00"
            }
        }
    ]
}
```
