### PR TITLE
✨ Add oauth redirection to the page before the api call to the web

### DIFF
--- a/server/src/routes/oauthRoute.js
+++ b/server/src/routes/oauthRoute.js
@@ -35,9 +35,12 @@ function extractRedirectFromState(req) {
     const parsed = JSON.parse(decodeURIComponent(state));
     if (parsed && typeof parsed.redirect_to === 'string') {
       const r = parsed.redirect_to;
-      if (r.startsWith('/')) return r;
+      if (r.startsWith('/') || r.includes('://')) {
+        return r;
+      }
     }
   } catch (e) {
+    console.error('Error extracting redirect from state:', e);
   }
   return '/';
 }

--- a/web/src/app/components/card-service/card-service.ts
+++ b/web/src/app/components/card-service/card-service.ts
@@ -24,6 +24,7 @@ export class CardService {
 
   connectService = () => {
     if (this.isBlocked()) return;
-    window.location.href = this.apiService.apiUrl + '/oauth/' + this.name.toLowerCase();
+    const redirectTo = encodeURIComponent(window.location.href);
+    window.location.href = `${this.apiService.apiUrl}/oauth/${this.name.toLowerCase()}?redirect_to=${redirectTo}`;
   };
 }


### PR DESCRIPTION
## Summary
This PR adds the redirection when calling the /api/oauth/* routes, by taking the user back to the page before the call
It also opens the road to implementation of URI redirections

## Related Jira Issue(s)
AREA-172 When connecting to Oauth redirect does not redirect

## Additions
- redirection to the website after /api/oauth* call
- handling of URI

## Testing
1. Go to the web client
2. Test any or all services and see if, after connecting, you are redirected to the page you were before

## Checklist
- [x] Source branch is based on `dev`
- [x] Linked to the correct Jira story
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [x] Documentation deployment CI must pass
